### PR TITLE
Adding options for equal size rows and columns

### DIFF
--- a/src/diagram.typ
+++ b/src/diagram.typ
@@ -27,7 +27,7 @@
 	} else {
 		error("Axes #0 cannot both be in the same direction. Try `axes: (ltr, ttb)`.", axes)
 	}
- 
+
 	(
 		flip: (
 			x: axes.at(0) in (rtl, ttb),
@@ -49,8 +49,8 @@
 ///
 /// This is the algorithm used to determine grid layout in diagrams.
 ///
-/// - rects (array): An array of rects of the form 
-///   `(center: (x, y), size: (width, height))`. The coordinates `x` and `y` may 
+/// - rects (array): An array of rects of the form
+///   `(center: (x, y), size: (width, height))`. The coordinates `x` and `y` may
 ///   be floats.
 /// -> array
 #let expand-fractional-rects(rects) = {
@@ -60,7 +60,7 @@
 		for rect in rects {
 			let coord = rect.center.at(axis)
 			let size = rect.size.at(axis)
-   
+
 			if calc.fract(coord) == 0 {
 				rect.center.at(axis) = calc.trunc(coord)
 				new-rects.push(rect)
@@ -94,7 +94,7 @@
 /// - rects (array): Rectangles (dictionaries of the form `(center, size)` which
 ///   are used to determine cell sizes.
 #let compute-cell-sizes(flip, verts, rects) = {
-  
+
 	if flip.xy {
 		// if x/y axes are flipped, transpose rectangles
 		rects = rects.map( ((center, size)) => {
@@ -108,7 +108,7 @@
 	points += verts
 
 	if points.len() == 0 { points.push((0,0)) }
- 
+
 	let min-max-int(a) = (calc.floor(calc.min(..a)), calc.ceil(calc.max(..a)))
 	let (x-min, x-max) = min-max-int(points.map(p => p.at(0)))
 	let (y-min, y-max) = min-max-int(points.map(p => p.at(1)))
@@ -117,7 +117,7 @@
 
 	// Initialise row and column sizes
 	let cell-sizes = bounding-dims.map(n => (0pt,)*n)
- 
+
 	// Expand cells to fit rects
 	for rect in rects {
 		let indices = vector.sub(rect.center, origin)
@@ -159,7 +159,7 @@
 			array.zip(cumsum(sizes), sizes, range(sizes.len()))
 				.map(((end, size, i)) => end - size/2 + spacing*i)
 		})
-  
+
 	let bounding-size = array.zip(centers, grid.cell-sizes)
 		.map(((centers, sizes)) => centers.at(-1) + sizes.at(-1)/2)
 
@@ -182,7 +182,7 @@
 
 	grid += interpret-axes(grid.axes)
 	grid += compute-cell-sizes(grid.flip, verts, rects)
- 
+
 	// enforce minimum cell size
 	grid.cell-sizes = grid.cell-sizes.zip(options.cell-size)
 		.map(((sizes, min-size)) => sizes.map(calc.max.with(min-size)))
@@ -270,7 +270,7 @@
 
 	let edges = ()
 	let nodes = ()
- 
+
 	// convert math matrix into array-of-arrays matrix
 	let matrix = ((none,),)
 	let (x, y) = (0, 0)
@@ -299,7 +299,7 @@
 			matrix.at(-1).at(-1) += child
 		}
 	}
- 
+
 	// turn matrix into an array of nodes
 	for (y, row) in matrix.enumerate() {
 		for (x, item) in row.enumerate() {
@@ -334,7 +334,7 @@
 			if obj.value.class == "node" {
 				let node = obj.value
 				nodes.push(node)
-    
+
 			} else if obj.value.class == "edge" {
 				let edge = obj.value
 				edge.node-index = nodes.len()
@@ -357,6 +357,9 @@
 	)
 
 }
+
+
+
 /// Draw a diagram containing `node()`s and `edge()`s.
 ///
 /// - ..args (array): Content to draw in the diagram, including nodes and edges.
@@ -371,10 +374,11 @@
 ///   	node((1, 0), $B$),
 ///   	{
 ///   		// multiple objects in a block
+///   		// can use scripting, loops, etc
 ///   		node((2, 0), $C$)
 ///   		node((3, 0), $D$)
 ///   	},
-///   	for x in range(4) { node((x, 1) [#x]) },
+///   	for x in range(4) { node((x, 1), [#x]) },
 ///   )
 ///   ```
 ///
@@ -383,7 +387,7 @@
 ///   ```typ
 ///   #diagram($
 ///   	A & B \          // two nodes at (0,0) and (1,0)
-///   	C edge(->) & D \ // an edge from (0,1) to (1,0)
+///   	C edge(->) & D \ // an edge from (0,1) to (1,1)
 ///   	node(sqrt(pi), stroke: #1pt) // a node with options
 ///   $)
 ///   ```
@@ -417,11 +421,11 @@
 ///   example, if `node-stroke` is `1pt` and #the-param[node][stroke] is `red`,
 ///   then the resulting stroke is `1pt + red`.
 ///
-/// - node-fill (paint): Default value of #the-param[node][fill`.
+/// - node-fill (paint): Default value of #the-param[node][fill].
 ///
 /// - edge-stroke (stroke): Default value of #the-param[edge][stroke]. By
-///   default, this is chosen to match the thickness of mathematical arrows
-///   such as $A -> B$ in the current font size.
+///   default, this is chosen to match the thickness of mathematical arrows such
+///   as $A -> B$ in the current font size.
 ///
 ///   The default stroke is folded with the stroke specified for the edge. For
 ///   example, if `edge-stroke` is `1pt` and #the-param[edge][stroke] is `red`,
@@ -535,10 +539,10 @@
 		cetz.canvas(draw-diagram(grid, nodes, edges, debug: options.debug))
 	},
 ) = {
-  
+
 	let spacing = as-pair(spacing).map(as-length)
 	let cell-size = as-pair(cell-size).map(as-length)
- 
+
 	let options = (
 		debug: int(debug),
 		axes: axes,
@@ -564,7 +568,7 @@
 		crossing-fill: crossing-fill,
 		crossing-thickness: crossing-thickness,
 	)
- 
+
 	let (nodes, edges) = interpret-diagram-args(args)
 
 	box(context {

--- a/src/diagram.typ
+++ b/src/diagram.typ
@@ -27,7 +27,7 @@
 	} else {
 		error("Axes #0 cannot both be in the same direction. Try `axes: (ltr, ttb)`.", axes)
 	}
-
+ 
 	(
 		flip: (
 			x: axes.at(0) in (rtl, ttb),
@@ -49,8 +49,8 @@
 ///
 /// This is the algorithm used to determine grid layout in diagrams.
 ///
-/// - rects (array): An array of rects of the form
-///   `(center: (x, y), size: (width, height))`. The coordinates `x` and `y` may
+/// - rects (array): An array of rects of the form 
+///   `(center: (x, y), size: (width, height))`. The coordinates `x` and `y` may 
 ///   be floats.
 /// -> array
 #let expand-fractional-rects(rects) = {
@@ -60,7 +60,7 @@
 		for rect in rects {
 			let coord = rect.center.at(axis)
 			let size = rect.size.at(axis)
-
+   
 			if calc.fract(coord) == 0 {
 				rect.center.at(axis) = calc.trunc(coord)
 				new-rects.push(rect)
@@ -94,7 +94,7 @@
 /// - rects (array): Rectangles (dictionaries of the form `(center, size)` which
 ///   are used to determine cell sizes.
 #let compute-cell-sizes(flip, verts, rects) = {
-
+  
 	if flip.xy {
 		// if x/y axes are flipped, transpose rectangles
 		rects = rects.map( ((center, size)) => {
@@ -108,7 +108,7 @@
 	points += verts
 
 	if points.len() == 0 { points.push((0,0)) }
-
+ 
 	let min-max-int(a) = (calc.floor(calc.min(..a)), calc.ceil(calc.max(..a)))
 	let (x-min, x-max) = min-max-int(points.map(p => p.at(0)))
 	let (y-min, y-max) = min-max-int(points.map(p => p.at(1)))
@@ -117,7 +117,7 @@
 
 	// Initialise row and column sizes
 	let cell-sizes = bounding-dims.map(n => (0pt,)*n)
-
+ 
 	// Expand cells to fit rects
 	for rect in rects {
 		let indices = vector.sub(rect.center, origin)
@@ -159,7 +159,7 @@
 			array.zip(cumsum(sizes), sizes, range(sizes.len()))
 				.map(((end, size, i)) => end - size/2 + spacing*i)
 		})
-
+  
 	let bounding-size = array.zip(centers, grid.cell-sizes)
 		.map(((centers, sizes)) => centers.at(-1) + sizes.at(-1)/2)
 
@@ -182,7 +182,7 @@
 
 	grid += interpret-axes(grid.axes)
 	grid += compute-cell-sizes(grid.flip, verts, rects)
-
+ 
 	// enforce minimum cell size
 	grid.cell-sizes = grid.cell-sizes.zip(options.cell-size)
 		.map(((sizes, min-size)) => sizes.map(calc.max.with(min-size)))
@@ -195,13 +195,82 @@
 	grid
 }
 
+
+// -----------------------------------------------------------------------------
+// Equalize node dimensions
+// -----------------------------------------------------------------------------
+//
+// When requested, nodes in the same column and/or row are given the same
+// width/height. The grid has already computed the maximum size required by
+// every column and row, so those values can be reused directly.
+//
+// This is deliberately performed after compute-grid() and before the final
+// physical coordinates are resolved.
+// -----------------------------------------------------------------------------
+#let equalize-node-sizes(
+	nodes,
+	grid,
+	equal-columns: false,
+	equal-rows: false,
+) = {
+	if not equal-columns and not equal-rows {
+		return nodes
+	}
+
+	nodes.map(node => {
+		// Nodes whose UV coordinates cannot be resolved do not belong
+		// to an ordinary row/column of the elastic grid.
+		if is-nan-vector(node.pos.uv) {
+			return node
+		}
+
+		let indices = vector.sub(node.pos.uv, grid.origin)
+
+		// Same convention as compute-cell-sizes().
+		if grid.flip.x {
+			indices.at(0) = -1 - indices.at(0)
+		}
+		if grid.flip.y {
+			indices.at(1) = -1 - indices.at(1)
+		}
+
+		// If the axes are transposed, the two dimensions have been
+		// transposed in cell-sizes as well.
+		if grid.flip.xy {
+			indices = indices.rev()
+		}
+
+		let col = calc.round(indices.at(0))
+		let row = calc.round(indices.at(1))
+
+		if equal-columns {
+			node.size.at(0) = grid.cell-sizes.at(0).at(col)
+		}
+
+		if equal-rows {
+			node.size.at(1) = grid.cell-sizes.at(1).at(row)
+		}
+
+		// measure-node-size() normally computes this value. Since we have
+		// changed the dimensions, keep it consistent.
+		node.aspect = if node.size.at(1) == 0pt {
+			1
+		} else {
+			node.size.at(0) / node.size.at(1)
+		}
+
+		node
+	})
+}
+
+
 #let extract-nodes-and-edges-from-equation(eq) = {
 	assert(eq.func() == math.equation)
 	let terms = flatten-sequence-to-array(eq.body)
 
 	let edges = ()
 	let nodes = ()
-
+ 
 	// convert math matrix into array-of-arrays matrix
 	let matrix = ((none,),)
 	let (x, y) = (0, 0)
@@ -230,7 +299,7 @@
 			matrix.at(-1).at(-1) += child
 		}
 	}
-
+ 
 	// turn matrix into an array of nodes
 	for (y, row) in matrix.enumerate() {
 		for (x, item) in row.enumerate() {
@@ -265,7 +334,7 @@
 			if obj.value.class == "node" {
 				let node = obj.value
 				nodes.push(node)
-
+    
 			} else if obj.value.class == "edge" {
 				let edge = obj.value
 				edge.node-index = nodes.len()
@@ -288,9 +357,6 @@
 	)
 
 }
-
-
-
 /// Draw a diagram containing `node()`s and `edge()`s.
 ///
 /// - ..args (array): Content to draw in the diagram, including nodes and edges.
@@ -305,11 +371,10 @@
 ///   	node((1, 0), $B$),
 ///   	{
 ///   		// multiple objects in a block
-///   		// can use scripting, loops, etc
 ///   		node((2, 0), $C$)
 ///   		node((3, 0), $D$)
 ///   	},
-///   	for x in range(4) { node((x, 1), [#x]) },
+///   	for x in range(4) { node((x, 1) [#x]) },
 ///   )
 ///   ```
 ///
@@ -318,7 +383,7 @@
 ///   ```typ
 ///   #diagram($
 ///   	A & B \          // two nodes at (0,0) and (1,0)
-///   	C edge(->) & D \ // an edge from (0,1) to (1,1)
+///   	C edge(->) & D \ // an edge from (0,1) to (1,0)
 ///   	node(sqrt(pi), stroke: #1pt) // a node with options
 ///   $)
 ///   ```
@@ -331,8 +396,8 @@
 ///   that nodes at adjacent grid points are at least this far apart (measured as
 ///   the space between their bounding boxes).
 ///
-///   Separate horizontal/vertical gutters can be specified with `(x, y)`. A
-///   single length `d` is short for `(d, d)`.
+///   Separate horizontal/vertical gutters can be specified with `(x, y)`.
+///   A single length `d` is short for `(d, d)`.
 ///
 /// - cell-size (length, pair of lengths): Minimum size of all rows and columns.
 ///   A single length `d` is short for `(d, d)`.
@@ -352,11 +417,11 @@
 ///   example, if `node-stroke` is `1pt` and #the-param[node][stroke] is `red`,
 ///   then the resulting stroke is `1pt + red`.
 ///
-/// - node-fill (paint): Default value of #the-param[node][fill].
+/// - node-fill (paint): Default value of #the-param[node][fill`.
 ///
 /// - edge-stroke (stroke): Default value of #the-param[edge][stroke]. By
-///   default, this is chosen to match the thickness of mathematical arrows such
-///   as $A -> B$ in the current font size.
+///   default, this is chosen to match the thickness of mathematical arrows
+///   such as $A -> B$ in the current font size.
 ///
 ///   The default stroke is folded with the stroke specified for the edge. For
 ///   example, if `edge-stroke` is `1pt` and #the-param[edge][stroke] is `red`,
@@ -440,6 +505,12 @@
 	axes: (ltr, ttb),
 	spacing: 3em,
 	cell-size: 0pt,
+
+	// New in this modified version:
+	// Make all nodes in the same column and/or row have equal dimensions.
+	equal-columns: false,
+	equal-rows: false,
+
 	edge-stroke: 0.048em,
 	node-stroke: none,
 	edge-corner-radius: 2.5pt,
@@ -464,15 +535,19 @@
 		cetz.canvas(draw-diagram(grid, nodes, edges, debug: options.debug))
 	},
 ) = {
-
+  
 	let spacing = as-pair(spacing).map(as-length)
 	let cell-size = as-pair(cell-size).map(as-length)
-
+ 
 	let options = (
 		debug: int(debug),
 		axes: axes,
 		spacing: spacing,
 		cell-size: cell-size,
+
+		equal-columns: equal-columns,
+		equal-rows: equal-rows,
+
 		node-inset: node-inset,
 		node-outset: node-outset,
 		node-shape: node-shape,
@@ -489,7 +564,7 @@
 		crossing-fill: crossing-fill,
 		crossing-thickness: crossing-thickness,
 	)
-
+ 
 	let (nodes, edges) = interpret-diagram-args(args)
 
 	box(context {
@@ -507,62 +582,52 @@
 		let edges = edges.map(edge => resolve-edge-options(edge, options))
 
 		// PHASE 1: Resolve uv coordinates where possible
-
-
-		let dummy-edge-anchors = edges
-			.filter(edge => edge.name != none)
-			.map(edge => (str(edge.name), (anchors: k => NAN_COORD)))
-			.to-dict()
-
-
-		let ctx = default-ctx + (target-system: "uv") + (nodes: dummy-edge-anchors)
-
 		// try resolving node uv coordinates. this resolves to NaN coords if the
 		// resolution fails (e.g., if the coords depend on physical lengths)
-		let (ctx, nodes) = resolve-node-coordinates(
-			nodes, ctx: ctx)
-
-
+		let (ctx-with-uv-anchors, nodes) = resolve-node-coordinates(
+			nodes, ctx: (target-system: "uv"))
 		// nodes and edges whose uv coordinates can be resolved without knowing the grid
 		let rects-affecting-grid = nodes
 			.filter(node => not is-nan-vector(node.pos.uv))
 			.map(node => (center: node.pos.uv, size: node.size))
-
 		let vertices-affecting-grid = (edges
-			.map(edge => resolve-edge-vertices(ctx, edge, nodes))
-			.join() + ()) // coerce none to ()
+			.map(edge => resolve-edge-vertices(edge, nodes, ctx: ctx-with-uv-anchors + (target-system: "uv")))
+			.join() + ())
 			.filter(vert => not is-nan-vector(vert))
 
-
 		// PHASE 2: Determine elastic grid (row/column sizes) and resolve xy coordinates
-
-		// determine diagram's elastic grid layout
 		let grid = compute-grid(rects-affecting-grid, vertices-affecting-grid, options)
 
-		let dummy-edge-anchors = edges
-			.filter(edge => edge.name != none)
-			.map(edge => (str(edge.name), (anchors: k => (0pt, 0pt))))
-			.to-dict()
+		// Equalize node dimensions AFTER the grid has been computed.
+		nodes = equalize-node-sizes(
+			nodes,
+			grid,
+			equal-columns: options.equal-columns,
+			equal-rows: options.equal-rows,
+		)
 
-
-		let ctx = default-ctx + (target-system: "xyz", grid: grid) + (nodes: dummy-edge-anchors)
-
-		// PHASE 3: With the grid defined, fully resolve xy coordinates for all nodes and edges
-
+		let ctx-with-xyz-anchors
 		// we run multiple passes so that anchors on enclose nodes
 		// have a chance to resolve
 		// (a better way would be to resolve coordinates and enclose nodes together)
 		for i in range(5) {
-			ctx.prev.pt = (0, 0)
-
 			// now with grid determined, compute final (physical) coordinates for nodes and edges
-			(ctx, nodes) = resolve-node-coordinates(nodes, ctx: ctx)
+			(ctx-with-xyz-anchors, nodes) = resolve-node-coordinates(
+				nodes, ctx: (target-system: "xyz", grid: grid))
 
 			// resolve enclosing nodes
-			nodes = resolve-node-enclosures(nodes, ctx)
-
-			(ctx, edges) = resolve-edges(grid, edges, nodes, ctx)
+			nodes = resolve-node-enclosures(nodes, ctx-with-xyz-anchors)
 		}
+		// resolve edges
+		edges = edges.map(edge => {
+			edge.final-vertices = resolve-edge-vertices(
+				edge, ctx: ctx-with-xyz-anchors + (target-system: "xyz", grid: grid), nodes
+			)
+
+			edge = convert-edge-corner-to-poly(edge)
+			edge = apply-edge-shift(grid, edge)
+			edge
+		})
 
 		render(grid, nodes, edges, options)
 	})


### PR DESCRIPTION
Solve issue https://github.com/Jollywatt/typst-fletcher/issues/160. 
Changes are only in diagram.typ

I know you are working on a new version ... this solve the problem on 0.5.8. 
I hope that's ok or can be an idea for the futur version.

